### PR TITLE
fix getvalue command failing if there is no claim to a name

### DIFF
--- a/src/blockchain_processor.py
+++ b/src/blockchain_processor.py
@@ -605,7 +605,9 @@ class BlockchainProcessor(Processor):
                 transaction = self.lbrycrdd('getrawtransaction', (proof['txhash'],))
                 result['transaction'] = transaction
             claim_info = self.lbrycrdd('getclaimsforname', (name,))
-            supports = claim_info['claims'][0]['supports']
+            supports = []
+            if len(claim_info['claims']) > 0: 
+                supports = claim_info['claims'][0]['supports']
             result['supports'] = [[support['txid'], support['n'], support['nAmount']] for support in supports]
 
         elif method == 'blockchain.claimtrie.getclaimsintx':


### PR DESCRIPTION
getvalue command will fail with "list index out of range" exception if called for a name that does not have any claims. 

You can reproduce this bug by running getvalueforname("some name that isnt claimed") on lbryum console