### PR TITLE
Fix unclaimed channel look ups 

### DIFF
--- a/lbryumserver/blockchain_processor.py
+++ b/lbryumserver/blockchain_processor.py
@@ -721,7 +721,7 @@ class BlockchainProcessor(Processor):
         elif method == 'blockchain.claimtrie.getclaimssignedbynthtoname':
             name = str(params[0])
             n = int(params[1])
-            certificate_id = str(self.storage.get_claimid_for_nth_claim_to_name(name, n))
+            certificate_id = self.storage.get_claimid_for_nth_claim_to_name(name, n)
             if certificate_id:
                 claims = self.storage.get_claims_signed_by(certificate_id)
                 result = [self.get_claim_info(claim_id) for claim_id in claims]

--- a/lbryumserver/storage.py
+++ b/lbryumserver/storage.py
@@ -656,12 +656,16 @@ class Storage(object):
 
     def get_claimid_for_nth_claim_to_name(self, name, n):
         claims = self.db_claim_order.get(name)
+        if claims is None:
+            return None
         for claim_id, i in json.loads(claims).iteritems():
             if i == n:
                 return claim_id
 
     def get_n_for_name_and_claimid(self, name, claim_id):
         claims = self.db_claim_order.get(name)
+        if claims is None:
+            return None
         for id, n in json.loads(claims).iteritems():
             if id == claim_id:
                 return n


### PR DESCRIPTION
Trying to resolve a  uri as:
some_name:n 
will raise an exception instead of returning None if the name is not claimed. 

get_claimid_for_nth_claim_to_name() and get_n_for_name_and_claimid() in Storage class needs to account for when there is no claim for the name and return None. Otherwise json.loads() of None will raise an exception. 

There is an unnecessary str() method under blokchain_processor method blockchain.claimtrie.getclaimssignedbynthtoname . Claim id should always be a string or None. If None, it will not hit the if statement underneath it. 


