### PR TITLE
Fix race condition in getvalue request

### DIFF
--- a/lbryumserver/blockchain_processor.py
+++ b/lbryumserver/blockchain_processor.py
@@ -660,26 +660,16 @@ class BlockchainProcessor(Processor):
                 args = args + (block_hash,)
             proof = self.lbrycrdd('getnameproof', args)
             result = {'proof': proof}
+            # if there is a claim on the name txhash and nOut will exist
             if 'txhash' in proof and 'nOut' in proof:
                 txid, nout = proof['txhash'], proof['nOut']
                 transaction_info = self.lbrycrdd('getrawtransaction', (proof['txhash'], 1))
                 transaction = transaction_info['hex']
-                transaction_height = self.lbrycrdd_height - transaction_info['confirmations']
+                transaction_height = self.lbrycrdd_height - transaction_info['confirmations'] +1
                 result['transaction'] = transaction
-                claim_id = self.storage.get_claim_id_from_outpoint(txid, nout)
-                result['claim_id'] = claim_id
-                claim_sequence = self.storage.get_n_for_name_and_claimid(str(name), claim_id)
-                result['claim_sequence'] = claim_sequence
-                result['height'] = transaction_height + 1
+                result['height'] = transaction_height
 
-            claim_info = self.lbrycrdd('getclaimsforname', (name,))
-            supports = []
-            if len(claim_info['claims']) > 0:
-                for claim in claim_info['claims']:
-                    if claim['claimId'] == claim_id:
-                        supports = claim['supports']
-                        break
-            result['supports'] = [[support['txid'], support['n'], support['nAmount']] for support in supports]
+
 
         elif method == 'blockchain.claimtrie.getclaimsintx':
             txid = params[0]


### PR DESCRIPTION
This lbryum request method suffers from multiple race condition issues https://github.com/lbryio/lbryum-server/blob/master/lbryumserver/blockchain_processor.py#L655

After making this call: 

proof = self.lbrycrdd('getnameproof', args)

The function assumes that the state of the blockchain is consistent when calling below commands: 

self.storage.get_claim_id_from_outpoint(txid, nout)

self.storage.get_n_for_name_and_claimid(str(name), claim_id)

self.lbrycrdd('getclaimsforname', (name,))

This assumption does not hold. For example, if a block is received that abandons the winning claim obtained in getnameproof function, self.storage.get_claim_id_from_outpoint(txid, nout) will return None. 

There is no way around this without more involved lbryum sever / lbrycrd modifications. This means that claim sequence and supports should be removed for the time being from getvalueforname command. (also means that effective amount, which is calculated from supports, will be removed from calculation on the lbryum client side). 

Also note that claim sequence and supports are not verifiable anyways by lbryum client (client has to trust what the server says, and cannot verify it unlike the name claim value) so its also logical to keep these out of the getvalue request. claim_sequence and supports can also still be obtained from getclaimsforname request (used in lbrynet daemon API claim_list )so apps that need this information can still get it. 
 
claim_id can be obtained from the transaction hex (if its an update its contained in the script, if its a claim it can be calculated from txid + nout) so this can be done on the lbryum client side. 

