### PR TITLE
Handle block reorgs properly

### DIFF
--- a/lbryumserver/blockchain_processor.py
+++ b/lbryumserver/blockchain_processor.py
@@ -11,7 +11,7 @@ from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
 
 from lbryumserver import deserialize
 from lbryumserver.processor import Processor, print_log
-from lbryumserver.storage import Storage
+from lbryumserver.claims_storage import ClaimsStorage
 from lbryumserver.utils import logger, hash_decode, hash_encode, Hash, header_from_string
 from lbryumserver.utils import header_to_string, ProfiledThread, rev_hex, int_to_hex, PoWHash
 
@@ -64,7 +64,7 @@ class BlockchainProcessorBase(Processor):
             self.test_reorgs = config.getboolean('leveldb', 'test_reorgs')  # simulate random blockchain reorgs
         except:
             self.test_reorgs = False
-        self.storage = Storage(config, shared, self.test_reorgs)
+        self.storage = ClaimsStorage(config, shared, self.test_reorgs)
 
         self.lbrycrdd_url = 'http://%s:%s@%s:%s/' % (
             config.get('lbrycrdd', 'lbrycrdd_user'),
@@ -419,7 +419,7 @@ class BlockchainProcessorBase(Processor):
             elif revert:
                 self.storage.revert_claim(claim, txid, nout)
             else:
-                undo_claim_info = self.storage.import_claim(claim, txid, nout,
+                undo_claim_info = self.storage.import_claim(claim, txid, nout, amount,
                                                             block_height, claim_address)
                 self.storage.write_undo_claim_info(block_height, self.lbrycrdd_height,
                                                    claim_id, undo_claim_info)
@@ -456,46 +456,33 @@ class BlockchainProcessorBase(Processor):
         # undo info
         if revert:
             undo_info = self.storage.get_undo_info(block_height)
+            claim_undo_info = self.storage.get_undo_claim_info(block_height)
             tx_hashes.reverse()
         else:
             undo_info = {}
-
+            claim_undo_info = {}
         for txid in tx_hashes:  # must be ordered
             tx = txdict[txid]
             if not revert:
                 undo = self.storage.import_transaction(txid, tx, block_height, touched_addr)
                 undo_info[txid] = undo
+
+                undo = self.storage.import_claim_transaction(txid, tx, block_height)
+                claim_undo_info[txid] = undo
             else:
                 undo = undo_info.pop(txid)
                 self.storage.revert_transaction(txid, tx, block_height, touched_addr, undo)
-
-            imported_claim = False
-
-            for x in tx.get('outputs'):
-                script = x.get('raw_output_script').decode('hex')
-                nout = x.get('index')
-                decoded_script = [s for s in deserialize.script_GetOp(script)]
-                out = deserialize.decode_claim_script(decoded_script)
-                if out is not False:
-                    claim, claim_script = out
-                    if self._is_valid_claim(claim, tx):
-                        self.import_claim_transaction(claim, script, txid, nout, block_height, revert)
-                        imported_claim = True
-
-            if not imported_claim:
-                # if there wasn't an update, make sure the tx didn't spend a claim
-                for x in tx.get('inputs'):
-                    txid, nout = x['prevout_hash'], x['prevout_n']
-                    claim_id = self.storage.get_claim_id_from_outpoint(txid, nout)
-                    if claim_id:
-                        self.storage.remove_claim(claim_id)
+                undo = claim_undo_info.pop(txid)
+                self.storage.revert_claim_transaction(undo)
 
         if revert:
+            assert claim_undo_info == {}
             assert undo_info == {}
 
         # add undo info
         if not revert:
             self.storage.write_undo_info(block_height, self.lbrycrdd_height, undo_info)
+            self.storage.write_undo_claim_info(block_height, self.lbrycrdd_height, claim_undo_info)
 
         # add the max
         self.storage.save_height(block_hash, block_height)
@@ -532,9 +519,10 @@ class BlockchainProcessorBase(Processor):
 
     def get_claim_info(self, claim_id):
         result = {}
+        logger.warn("get_claim_info claim_id:{}".format(claim_id))
         claim_name = self.storage.get_claim_name(claim_id)
         claim_value = self.storage.get_claim_value(claim_id)
-        claim_out = self.storage.get_txid_nout_from_claim_id(claim_id)
+        claim_out = self.storage.get_outpoint_from_claim_id(claim_id)
         claim_height = self.storage.get_claim_height(claim_id)
         claim_address = self.storage.get_claim_address(claim_id)
         if claim_name and claim_id:
@@ -542,20 +530,20 @@ class BlockchainProcessorBase(Processor):
         else:
             claim_sequence = None
         if None not in (claim_name, claim_value, claim_out, claim_height, claim_sequence):
-            claim_txid, claim_nout = claim_out
+            claim_txid, claim_nout, claim_amount = claim_out
             claim_value = claim_value.encode('hex')
             result = {
                 "name": claim_name,
                 "claim_id": claim_id,
                 "txid": claim_txid,
                 "nout": claim_nout,
+                "amount":claim_amount,
                 "depth": self.lbrycrdd_height - claim_height,
                 "height": claim_height,
                 "value": claim_value,
                 "claim_sequence": claim_sequence,
                 "address": claim_address
             }
-
             lbrycrdd_results = self.lbrycrdd("getclaimsforname", (claim_name, ))
             lbrycrdd_claim = None
             if lbrycrdd_results:
@@ -566,7 +554,6 @@ class BlockchainProcessorBase(Processor):
                 if lbrycrdd_claim:
                     result['supports'] = [[support['txid'], support['n'], support['nAmount']] for
                                           support in lbrycrdd_claim['supports']]
-                    result['amount'] = lbrycrdd_claim['nAmount']
                     result['effective_amount'] = lbrycrdd_claim['nEffectiveAmount']
                     result['valid_at_height'] = lbrycrdd_claim['nValidAtHeight']
 
@@ -1062,7 +1049,7 @@ class BlockchainProcessor(BlockchainProcessorBase):
         name = str(name)
         winning_claim = self.lbrycrdd('getvalueforname', (name,))
         if winning_claim:
-            certificate_id = winning_claim['claimId']
+            certificate_id = str(winning_claim['claimId'])
             claims = self.storage.get_claims_signed_by(certificate_id)
             return [self.get_claim_info(claim_id) for claim_id in claims]
 

--- a/lbryumserver/blockchain_processor.py
+++ b/lbryumserver/blockchain_processor.py
@@ -981,16 +981,17 @@ class BlockchainProcessor(BlockchainProcessorBase):
             transaction_height = self.lbrycrdd_height - transaction_info['confirmations']
             result['transaction'] = transaction
             claim_id = self.storage.get_claim_id_from_outpoint(txid, nout)
-            result['claim_id'] = claim_id
-            claim_sequence = self.storage.get_n_for_name_and_claimid(str(name), claim_id)
-            result['claim_sequence'] = claim_sequence
             result['height'] = transaction_height + 1
 
         claim_info = self.lbrycrdd('getclaimsforname', (name,))
         supports = []
         if len(claim_info['claims']) > 0:
             for claim in claim_info['claims']:
-                if claim['claimId'] == claim_id:
+                if claim['txid'] == txid and claim['n'] == nout:
+                    claim_id = claim['claimId']
+                    result['claim_id'] = claim_id
+                    claim_sequence = self.storage.get_n_for_name_and_claimid(str(name), claim_id)
+                    result['claim_sequence'] = claim_sequence
                     supports = claim['supports']
                     break
         result['supports'] = [[support['txid'], support['n'], support['nAmount']] for support in

--- a/lbryumserver/claims_storage.py
+++ b/lbryumserver/claims_storage.py
@@ -1,0 +1,400 @@
+"""
+this file contains ClaimsStorage class which contains
+functions to manipulate the claim information
+"""
+
+import pickle
+
+from lbryschema.decode import smart_decode
+from lbryschema.error import DecodeError, URIParseError, CertificateError
+from lbryschema.uri import parse_lbry_uri
+
+from lbryumserver import deserialize
+from lbryumserver.storage import Storage
+from lbryumserver.processor import logger
+from lbryumserver.utils import int_to_hex,hex_to_int
+
+class ClaimsStorage(Storage):
+    def __init__(self, config, shared, test_reorgs):
+        Storage.__init__(self, config, shared, test_reorgs)
+
+    def get_claimid_for_nth_claim_to_name(self, name, n):
+        claims = self.db_claim_order.get(name)
+        if claims is None:
+            return None
+        for claim_id, i in pickle.loads(claims).iteritems():
+            if i == n:
+                return claim_id
+
+    def get_n_for_name_and_claimid(self, name, claim_id):
+        claims = self.db_claim_order.get(name)
+        if claims is None:
+            return None
+        for id, n in pickle.loads(claims).iteritems():
+            if id == claim_id:
+                return n
+
+    def get_claim_id_from_outpoint(self, txid, nout):
+        #TODO: may want to look into keeping a db of txid nout to outpoint
+        # if too slow here
+        for claim_id, txid_nout_amount in self.db_claim_outpoint.db.iterator():
+            c_txid = txid_nout_amount[0:64]
+            c_nout = hex_to_int(txid_nout_amount[64:72].decode('hex'))
+            logger.warn('get_claim_id_from_outpoint:{}:{}, {}:{}'.format(txid,nout,c_txid,c_nout))
+            if txid == c_txid and nout == c_nout:
+                return claim_id
+
+    def get_outpoint_from_claim_id(self, claim_id):
+        txid_nout = self.db_claim_outpoint.get(claim_id)
+        if txid_nout is None:
+            return None
+        txid = txid_nout[0:64]
+        nout = hex_to_int(txid_nout[64:72].decode('hex'))
+        amount = hex_to_int(txid_nout[72:88].decode('hex'))
+        return txid, nout, amount
+
+    def write_outpoint_from_claim_id(self, claim_id, txid, nout, amount):
+        txid_nout_amount = txid+int_to_hex(nout, 4)+int_to_hex(amount,8)
+        self.db_claim_outpoint.put(claim_id, txid_nout_amount)
+
+    def get_claims_for_name(self, name):
+        claims = self.db_claim_order.get(name)
+        if claims is None:
+            return {}
+        return pickle.loads(claims)
+
+    def write_claims_for_name(self, name, claims):
+        if len(claims) == 0:
+            self.db_claim_order.delete(name)
+        else:
+            claims = pickle.dumps(claims)
+            self.db_claim_order.put(name, claims)
+
+    def get_claims_signed_by(self, certificate_id):
+        claims = self.db_cert_to_claims.get(certificate_id)
+        if claims is None:
+            return []
+        return pickle.loads(claims)
+
+    def write_claims_signed_by(self, certificate_id, claims):
+        if len(claims) == 0:
+            self.db_cert_to_claims.delete(certificate_id)
+        else:
+            self.db_cert_to_claims.put(certificate_id,pickle.dumps(claims))
+
+    def get_claim_value(self, claim_id):
+        return self.db_claim_values.get(claim_id)
+
+    def get_claim_height(self, claim_id):
+        height = self.db_claim_height.get(claim_id)
+        if height is not None:
+            return int(height)
+
+    def get_claim_address(self, claim_id):
+        return self.db_claim_addrs.get(claim_id)
+
+    def get_claim_name(self, claim_id):
+        return self.db_claim_names.get(claim_id)
+
+
+    def get_undo_claim_info(self, height):
+        s = self.db_undo_claim.get("undo_info_%d"%(height%100))
+        if s is None:
+            print_log('no undo info for {}'.format(height))
+            return None
+        return pickle.loads(s)
+
+    def write_undo_claim_info(self, height, lbrycrdd_height, undo_info):
+        if height > lbrycrdd_height - 100 or self.test_reorgs:
+            self.db_undo_claim.put("undo_info_%d" % (height % 100), pickle.dumps(undo_info))
+
+
+    def _get_claim_id(self, txid, nout):
+        """ get claim id in hex from txid in hex and nout int """
+        claim_id = deserialize.claim_id_hash(deserialize.rev_hex(txid).decode('hex'),nout)
+        claim_id = deserialize.claim_id_bytes_to_hex(claim_id)
+        return claim_id
+
+
+    def _get_undo_info(self, claim_type, claim_id, claim_name):
+        undo_info={"claim_id":claim_id,"claim_type":claim_type,"claim_name":claim_name}
+        if claim_type != 'claim':
+            undo_info['claim_outpoint'] = self.db_claim_outpoint.get(claim_id)
+            undo_info['claim_names'] = claim_name
+            undo_info['claim_values']= self.db_claim_values.get(claim_id)
+            undo_info['claim_height']= self.db_claim_height.get(claim_id)
+            undo_info['claim_addrs']= self.db_claim_addrs.get(claim_id)
+
+        undo_info['claim_order']= self.db_claim_order.get(claim_name)
+        return undo_info
+
+    def _is_valid_claim(self, claim, tx):
+        """
+        TODO: must be the first update (for the claim) in tx if there is more than one
+        """
+        if type(claim) == deserialize.ClaimUpdate:
+            claim_id = deserialize.claim_id_bytes_to_hex(claim.claim_id)
+            claim_name = self.get_claim_name(claim_id)
+            # claim is invalid if its name does not match
+            # what its updating
+            if claim_name != claim.name:
+                return False
+            # claim is invalid if it does not spend the claim it
+            # is updating
+            for i in tx.get('inputs'):
+                txid = i['prevout_hash']
+                nout = i['prevout_n']
+                if claim_id == self.get_claim_id_from_outpoint(txid, nout):
+                    return True
+            logger.warn("found invalid update {} for {}".format(claim_id, claim.name))
+            return False
+        else:
+            return True
+
+    def revert_claim_transaction(self, undo_infos):
+        """ revert claim transaction using undo information"""
+        for undo_info in undo_infos:
+            claim_id = undo_info['claim_id']
+            claim_name = undo_info['claim_name']
+            claim_type = undo_info['claim_type']
+            if claim_type == 'update':
+                self.db_claim_outpoint.put(claim_id, undo_info['claim_outpoint'])
+                self.db_claim_names.put(claim_id, undo_info['claim_names'])
+                self.db_claim_values.put(claim_id, undo_info['claim_values'])
+                self.db_claim_height.put(claim_id, undo_info['claim_height'])
+                self.db_claim_addrs.put(claim_id, undo_info['claim_addrs'])
+                self.db_claim_order.put(claim_name, undo_info['claim_order'])
+
+                if 'cert_to_claims' in undo_info:
+                    cert_id = undo_info['cert_to_claims'][0]
+                    claims = undo_info['cert_to_claims'][1]
+                    self.write_claims_signed_by(cert_id, claims)
+                    prev_cert_id = undo_info['prev_cert_to_claims'][0]
+                    prev_claims = undo_info['prev_cert_to_claims'][1]
+                    self.write_claims_signed_by(prev_cert_id,prev_claims)
+                    self.db_claim_to_cert.put(claim_id,undo_info['claim_to_cert'])
+
+            elif claim_type == 'claim':
+                self.db_claim_outpoint.delete(claim_id)
+                self.db_claim_names.delete(claim_id)
+                self.db_claim_values.delete(claim_id)
+                self.db_claim_height.delete(claim_id)
+                self.db_claim_addrs.delete(claim_id)
+                if undo_info['claim_order'] is not None:
+                    self.db_claim_order.put(claim_name, undo_info['claim_order'])
+                else:
+                    self.db_claim_order.delete(claim_name)
+
+                if 'cert_to_claims' in undo_info:
+                    cert_id = undo_info['cert_to_claims'][0]
+                    claims = undo_info['cert_to_claims'][1]
+                    self.write_claims_signed_by(cert_id, claims)
+                    self.db_claim_to_cert.delete(claim_id)
+
+            elif claim_type == 'abandon':
+                self.db_claim_outpoint.put(claim_id, undo_info['claim_outpoint'])
+                self.db_claim_names.put(claim_id, undo_info['claim_names'])
+                self.db_claim_values.put(claim_id, undo_info['claim_values'])
+                self.db_claim_height.put(claim_id, undo_info['claim_height'])
+                self.db_claim_addrs.put(claim_id, undo_info['claim_addrs'])
+                self.db_claim_order.put(claim_name, undo_info['claim_order'])
+
+                if 'cert_to_claims' in undo_info:
+                    cert_id = undo_info['cert_to_claims'][0]
+                    claims = undo_info['cert_to_claims'][1]
+                    self.write_claims_signed_by(cert_id, claims)
+                    self.db_claim_to_cert.put(claim_id, undo_info['claim_to_cert'])
+
+            else:
+                raise Exception('unhandled claim_type:{}'.format(claim_type))
+
+    def _analyze_tx(self, txid, tx):
+        """ analyze transaction to get list of abandons and claims """
+        #dict of abandons where key = claim_id , value = {'txid', 'nout',}
+        abandons = dict()
+        #list of claims : [{'claim': , 'nout':, 'claim_id', 'claim_address': 'amount':}, ]
+        list_claims = []
+        for x in tx.get('inputs'):
+            claim_id = self.get_claim_id_from_outpoint(x['prevout_hash'], x['prevout_n'])
+            if claim_id:
+                abandons[claim_id] = {'txid':x['prevout_hash'],'nout':x['prevout_n']}
+
+        for x in tx.get('outputs'):
+            script = x.get('raw_output_script').decode('hex')
+            nout = x.get('index')
+            amount = x.get('value')
+            decoded_script = [s for s in deserialize.script_GetOp(script)]
+            out = deserialize.decode_claim_script(decoded_script)
+            if out is False:
+                continue
+            claim, claim_script = out
+            claim_address = deserialize.get_address_from_output_script(script)
+            if not self._is_valid_claim(claim, tx):
+                continue
+            if type(claim) in [ deserialize.NameClaim, deserialize.ClaimSupport]:
+                claim_id = self._get_claim_id(txid,nout)
+            else:#ClaimUpdate
+                claim_id = deserialize.claim_id_bytes_to_hex(claim.claim_id)
+                del abandons[claim_id]
+
+            claim_info= {'claim':claim,'nout':nout,'claim_id':claim_id,'claim_address':claim_address,'amount':amount}
+            list_claims.append(claim_info)
+
+        return {'abandons':abandons,'claims':list_claims,}
+
+
+    def import_claim_transaction(self, txid, tx, block_height):
+        out = self._analyze_tx(txid, tx)
+        undo_infos =[]
+        for claim_id,claim_info in out['abandons'].iteritems():
+            undo_infos.append(
+                self.import_abandon(claim_info['txid'], claim_info['nout']))
+
+        for c in out['claims']:
+            if type(c['claim']) in [deserialize.NameClaim, deserialize.ClaimUpdate]:
+                undo_infos.append(
+                    self.import_claim(c['claim'], c['claim_id'], c['claim_address'],
+                                  txid, c['nout'], c['amount'], block_height))
+            else: #support
+                pass
+
+        undo_infos.reverse()
+        return undo_infos
+
+    def import_claim(self, claim, claim_id, claim_address, txid, nout, amount, block_height):
+        logger.info("importing claim {}, claim id:{}, txid:{}, nout:{} ".format(claim, claim_id, txid, nout))
+
+        is_update = type(claim) == deserialize.ClaimUpdate
+        if is_update:
+            claim_type = 'update'
+        else:
+            claim_type = 'claim'
+
+        undo_info = self._get_undo_info(claim_type, claim_id, claim.name)
+
+        claims_for_name = self.get_claims_for_name(claim.name)
+        if not claims_for_name:
+            claim_n = 1
+        else:
+            claim_n = max(i for i in claims_for_name.itervalues()) + 1
+
+        claims_for_name[claim_id] = claim_n
+        self.write_claims_for_name(claim.name, claims_for_name)
+
+        self.write_outpoint_from_claim_id(claim_id, txid, nout, amount)
+        self.db_claim_names.put(claim_id, claim.name)
+        self.db_claim_values.put(claim_id, claim.value)
+        self.db_claim_height.put(claim_id, str(block_height))
+        self.db_claim_addrs.put(claim_id, claim_address)
+
+        undo_info = self.import_signed_claim(claim, claim_id, undo_info)
+        return undo_info
+
+    def import_abandon(self, txid, nout):
+        """ handle abandoned claims """
+        claim_id = self.get_claim_id_from_outpoint(txid, nout)
+        claim_name = self.get_claim_name(claim_id)
+        if claim_id is None:
+            return
+
+        undo_info = self._get_undo_info('abandon', claim_id, claim_name)
+        self.db_claim_outpoint.delete(claim_id)
+        self.db_claim_values.delete(claim_id)
+        self.db_claim_height.delete(claim_id)
+        self.db_claim_addrs.delete(claim_id)
+        self.db_claim_names.delete(claim_id)
+
+        claims_in_db = self.db_claim_order.get(claim_name)
+        claims_for_name = {} if not claims_in_db else pickle.loads(claims_in_db)
+        claim_n = claims_for_name[claim_id]
+        del claims_for_name[claim_id]
+
+        for cid,cn in claims_for_name.iteritems():
+            if cn > n:
+                claims_for_name[cid] = cn-1
+
+
+        self.db_claim_order.delete(claim_name)
+        self.db_claim_order.put(claim_name, pickle.dumps(claims_for_name))
+
+        undo_info = self.import_signed_claim_abandon(claim_id, undo_info)
+        return undo_info
+
+
+    def _get_signed_claim_undo_info(self, claim_type, undo_info, cert_id, prev_cert_id=None):
+        """ add to undo_info signed claim related undo information """
+
+        if claim_type == 'claim':
+            claims = self.get_claims_signed_by(cert_id)
+            undo_info['cert_to_claims'] = (cert_id,claims)
+        elif claim_type == 'update':
+            if prev_cert_id != cert_id:
+                prev_claims = self.get_claims_signed_by(prev_cert_id)
+                claims = self.get_claims_signed_by(cert_id)
+                undo_info['prev_cert_to_claims'] = (prev_cert_id,prev_claims)
+                undo_info['cert_to_claims'] = (cert_id,claims)
+                undo_info['claim_to_cert'] = prev_cert_id
+
+        elif claim_type == 'abandon':
+            claims = self.get_claims_signed_by(cert_id)
+            undo_info['cert_to_claims'] = (cert_id,claims)
+            undo_info['claim_to_cert'] = cert_id
+        else:
+            raise Exception("unhandled type:{}".format(claim_type))
+
+        return undo_info
+
+    def import_signed_claim(self, claim, claim_id, undo_info):
+        """ handle the import of claims signed """
+        try:
+            decoded_claim = smart_decode(claim.value)
+            parsed_uri = parse_lbry_uri(claim.name)
+        except DecodeError:
+            logger.warn("decode error for lbry://{}#{}".format(claim.name, claim_id))
+            return undo_info
+        except URIParseError:
+            logger.warn("uri parse error for lbry://{}#{}".format(claim.name, claim_id))
+            return undo_info
+        if not decoded_claim.has_signature:
+            return undo_info
+
+        cert_id = decoded_claim.certificate_id
+        prev_cert_id = None
+        claim_type = 'claim'
+        if type(claim) == deserialize.ClaimUpdate:
+            prev_cert_id  = self.db_claim_to_cert(claim_id)
+            claim_type = 'update'
+        undo_info = self._get_signed_claim_undo_info(claim_type, undo_info, cert_id, prev_cert_id)
+
+        if claim_type == 'update':
+            if prev_cert_id != cert_id:
+                prev_claims = self.get_claims_signed_by(prev_cert_id)
+                prev_claims.remove(claim_id)
+                self.write_claims_signed_by(prev_cert_id, prev_claims)
+
+                claims = self.get_claims_signed_by(cert_id)
+                claims.append(claim_id)
+                self.write_claims_signed_by(cert_id,claims)
+
+                self.db_claim_to_cert.put(clam_id, cert_id)
+        elif claim_type == 'claim':
+            self.db_claim_to_cert.put(claim_id, cert_id)
+            claims = self.get_claims_signed_by(cert_id)
+            claims.append(claim_id)
+            self.write_claims_signed_by(cert_id, claims)
+        else:
+            raise Exception('unhandled type:{}'.format(claim_type))
+
+        return undo_info
+
+    def import_signed_claim_abandon(self, claim_id, undo_info):
+        """ handle abandons of claims signed  """
+        cert_id = self.db_claim_to_cert.get(claim_id)
+        if cert_id is not None:
+            undo_info = self._get_signed_claim_undo_info('abandon', undo_info, cert_id)
+            claims = self.get_claims_signed_by(cert_id)
+            claims.remove(claim_id)
+            self.write_claims_signed_by(cert_id, claims)
+            self.db_claim_to_cert.delete(claim_id)
+
+        return undo_info

--- a/lbryumserver/deserialize.py
+++ b/lbryumserver/deserialize.py
@@ -340,7 +340,8 @@ class NameClaim(object):
     def __init__(self, name, value):
         self.name = name
         self.value = value
-
+    def __repr__(self):
+        return "NameClaim, name:{}, value:{}".format(self.name,self.value)
 
 class ClaimUpdate(object):
     def __init__(self, name, claim_id, value):
@@ -348,12 +349,15 @@ class ClaimUpdate(object):
         self.claim_id = claim_id
         self.value = value
 
-
+    def __repr__(self):
+        return "ClaimUpdate, name:{}, claim_id:{}, value:{}".format(self.name, self.claim_id, self.value)
 class ClaimSupport(object):
     def __init__(self, name, claim_id):
         self.name = name
         self.claim_id = claim_id
 
+    def __repr__(self):
+        return "ClaimSupport, name:{}, claim_id:{}".format(self.name, self.claim_id)
 
 def decode_claim_script(decoded_script):
     if len(decoded_script) <= 6:

--- a/lbryumserver/storage.py
+++ b/lbryumserver/storage.py
@@ -7,6 +7,7 @@ import ast
 import os
 import threading
 import json
+import pickle
 
 from ecdsa.keys import BadSignatureError
 
@@ -187,25 +188,30 @@ class Storage(object):
             self.db_addr = DB(self.dbpath, 'addr', config.getint('leveldb', 'addr_cache'))
             # key = undo id, valude = undo info
             self.db_undo = DB(self.dbpath, 'undo', None)
-            # key = claim id hex, value = txid hex sting + nout
-            self.db_claimid = DB(self.dbpath, 'claimid', config.getint('leveldb', 'claimid_cache'))
-            # key = claim id hex, value = undo info
+
+            """ Below databases are for storing claim information """
+
+            # key = undo id, value = undo info
             self.db_undo_claim = DB(self.dbpath, 'undo_claim', 256 * 1024 * 1024)
+            # key = claim id hex, value = txid hex sting + nout + amount
+            self.db_claim_outpoint = DB(self.dbpath, 'claim_outpoint', config.getint('leveldb', 'claimid_cache'))
+            # key = claim id hex, value = claim name
+            self.db_claim_names = DB(self.dbpath, 'claim_names', 64 * 1024 * 1024)
             # key = claim id hex, value = claim value
             self.db_claim_values = DB(self.dbpath, 'claim_values',
                                       config.getint('leveldb', 'claim_value_cache'))
             # key = claim id hex, value = claim height
             self.db_claim_height = DB(self.dbpath, 'claim_height', 4 * 1024 * 1024)
-            # key = claim id hex, value = claim name
-            self.db_claim_names = DB(self.dbpath, 'claim_names', 64 * 1024 * 1024)
-            # key = claim name, value = {claim_id:claim_sequence,}
-            self.db_claim_order = DB(self.dbpath, 'claim_order', 4 * 1024 * 1024)
-            # key = claim id, value = claim value
-            self.db_certificate_claims = DB(self.dbpath, 'certificate_claim', 128 * 1024 * 1024)
-            # key = claim_id hex, value = certificate id
-            self.db_signed_claims = DB(self.dbpath, 'signed_claims', 256 * 1024 * 1024)
             # key = claim id hex, value = address
             self.db_claim_addrs = DB(self.dbpath, 'claim_addresses', 64 * 1024 * 1024)
+
+            # key = claim name, value = {claim_id:claim_sequence,}
+            self.db_claim_order = DB(self.dbpath, 'claim_order', 4 * 1024 * 1024)
+            # key = certificate claim_id hex, value = [claim_id,]
+            self.db_cert_to_claims = DB(self.dbpath, 'cert_to_claims', 256 * 1024 * 1024)
+            # key = claim id, value = certifcate claim id
+            self.db_claim_to_cert = DB(self.dbpath, 'claims_to_cert', 8 * 1024 * 1024)
+
         except:
             logger.error('db init', exc_info=True)
             self.shared.stop()
@@ -319,43 +325,22 @@ class Storage(object):
         out = sorted(out)
         return map(lambda x: {'height': x[0], 'tx_hash': x[1]}, out)
 
-    def get_claim_value(self, claim_id):
-        return self.db_claim_values.get(claim_id)
 
-    def get_claim_height(self, claim_id):
-        height = self.db_claim_height.get(claim_id)
-        if height is not None:
-            return int(height)
-
-    def get_claim_address(self, claim_id):
-        return self.db_claim_addrs.get(claim_id)
-
-    def get_claim_name(self, claim_id):
-        return self.db_claim_names.get(claim_id)
 
     def get_address(self, txi):
         return self.db_addr.get(txi)
 
-    def get_undo_claim_info(self, claim_id):
-        s = self.db_undo_claim.get(claim_id)
-        if s is None:
-            print_log('no undo info for {}'.format(claim_id))
-
-        return eval(s)
-
-    def write_undo_claim_info(self, height, lbrycrdd_height, claim_id, undo_info):
-        if height > lbrycrdd_height - 100 or self.test_reorgs:
-            self.db_undo_claim.put(claim_id, repr(undo_info))
 
     def get_undo_info(self, height):
         s = self.db_undo.get("undo_info_%d" % (height % 100))
         if s is None:
             print_log("no undo info for ", height)
-        return eval(s)
+            return None
+        return pickle.loads(s)
 
     def write_undo_info(self, height, lbrycrdd_height, undo_info):
         if height > lbrycrdd_height - 100 or self.test_reorgs:
-            self.db_undo.put("undo_info_%d" % (height % 100), repr(undo_info))
+            self.db_undo.put("undo_info_%d" % (height % 100), pickle.dumps(undo_info))
 
     @staticmethod
     def common_prefix(word1, word2):
@@ -382,7 +367,7 @@ class Storage(object):
         path = self.get_path(target, new=True)
         if path is True:
             return
-        # print "add key: target", target.encode('hex'), "path", map(lambda x: x.encode('hex'), path)
+        #print_log("add key: target", target.encode('hex'), "path", map(lambda x: x.encode('hex'), path))
         parent = path[-1]
         parent_node = self.get_node(parent)
         n = len(parent)
@@ -522,7 +507,7 @@ class Storage(object):
 
     def delete_key(self, leaf):
         path = self.get_path(leaf)
-        # print "delete key", leaf.encode('hex'), map(lambda x: x.encode('hex'), path)
+        #print_log("delete key", leaf.encode('hex'), map(lambda x: x.encode('hex'), path))
 
         s = self.db_utxo.get(leaf)
         self.db_utxo.delete(leaf)
@@ -536,7 +521,7 @@ class Storage(object):
         parent_node.remove(letter)
 
         # remove key if it has a single child
-        if parent_node.is_singleton(parent):
+        if parent_node.is_singleton(parent) and parent != '':
             # print "deleting parent", parent.encode('hex')
             self.db_utxo.delete(parent)
             if parent in self.hash_list:
@@ -546,7 +531,6 @@ class Storage(object):
             _hash, value = parent_node.get(l)
             skip = self.get_skip(parent + l)
             otherleaf = parent + l + skip
-            # update skip value in grand-parent
             gp = path[-2]
             gp_items = self.get_node(gp)
             letter = otherleaf[len(gp)]
@@ -578,16 +562,16 @@ class Storage(object):
         return self.root_hash if self.root_hash else ''
 
     def batch_write(self):
-        for db in [self.db_utxo, self.db_addr, self.db_hist, self.db_undo, self.db_claimid,
+        for db in [self.db_utxo, self.db_addr, self.db_hist, self.db_undo, self.db_claim_outpoint,
                    self.db_claim_values, self.db_claim_height, self.db_claim_names,
-                   self.db_claim_order, self.db_certificate_claims, self.db_signed_claims,
+                   self.db_claim_order, self.db_cert_to_claims, self.db_claim_to_cert,
                    self.db_claim_addrs]:
             db.write()
 
     def close(self):
-        for db in [self.db_utxo, self.db_addr, self.db_hist, self.db_undo, self.db_claimid,
+        for db in [self.db_utxo, self.db_addr, self.db_hist, self.db_undo, self.db_claim_outpoint,
                    self.db_claim_values, self.db_claim_height, self.db_claim_names,
-                   self.db_claim_order, self.db_certificate_claims, self.db_signed_claims,
+                   self.db_claim_order, self.db_cert_to_claims, self.db_claim_to_cert,
                    self.db_claim_addrs]:
             db.close()
 
@@ -653,206 +637,6 @@ class Storage(object):
         assert s[-80:-44] == txi
         s = s[:-80]
         self.db_hist.put(addr, s)
-
-    # get claim id in hex from txid in hex and nout int
-    def _get_claim_id(self, txid, nout):
-        claim_id = deserialize.claim_id_hash(deserialize.rev_hex(txid).decode('hex'),nout)
-        claim_id = deserialize.claim_id_bytes_to_hex(claim_id)
-        return claim_id
-
-    # get claim id from db from claim outpoint
-    def get_claim_id_from_outpoint(self, txid, nout):
-        txid_nout = txid + int_to_hex(nout, 4)
-        for claim_id, tx in self.db_claimid.db:
-            if txid_nout == tx:
-                return claim_id
-
-    def get_claimid_for_nth_claim_to_name(self, name, n):
-        claims = self.db_claim_order.get(name)
-        if claims is None:
-            return None
-        for claim_id, i in json.loads(claims).iteritems():
-            if i == n:
-                return claim_id
-
-    def get_n_for_name_and_claimid(self, name, claim_id):
-        claims = self.db_claim_order.get(name)
-        if claims is None:
-            return None
-        for id, n in json.loads(claims).iteritems():
-            if id == claim_id:
-                return n
-
-    def get_txid_nout_from_claim_id(self, claim_id):
-        txid_nout = self.db_claimid.get(claim_id)
-        if txid_nout is None:
-            return None
-        txid = txid_nout[0:64]
-        nout = hex_to_int(txid_nout[64:72].decode('hex'))
-        return txid, nout
-
-    def _iter_claims_signed_by(self, certificate_id):
-        for claim_id, cert_id in self.db_signed_claims.db:
-            if certificate_id == cert_id:
-                yield claim_id
-
-    def get_claims_signed_by(self, certificate_id):
-        return list(self._iter_claims_signed_by(certificate_id))
-
-    def update_channel_validations(self, claim, claim_id):
-        claim_address = self.db_claim_addrs.get(claim_id)
-        try:
-            decoded_claim = smart_decode(claim.value)
-            parsed_uri = parse_lbry_uri(claim.name)
-        except DecodeError:
-            print_log("decode error in update for lbry://{}#{}".format(claim.name, claim_id))
-            self.remove_claim(claim_id, delete_claim_data=False)
-            return
-        except URIParseError:
-            print_log("uri parse error for lbry://{}#{}".format(claim.name, claim_id))
-            self.remove_claim(claim_id, delete_claim_data=False)
-            return
-
-        if parsed_uri.is_channel and decoded_claim.is_certificate:
-            if self.db_certificate_claims.get(claim_id):
-                print_log("reindexing lbry://{}#{}".format(claim.name, claim_id))
-                self.db_certificate_claims.delete(claim_id)
-            else:
-                print_log("adding channel lbry://{}#{}".format(claim.name, claim_id))
-            self.db_certificate_claims.put(claim_id, claim.value)
-
-            for claim_id_to_check in self.get_claims_signed_by(claim_id):
-                address_to_check = self.db_claim_addrs.get(claim_id)
-                name = self.get_claim_name(claim_id_to_check)
-                decoded_claim_to_check = smart_decode(self.db_claim_values.get(claim_id_to_check))
-                try:
-                    is_valid = decoded_claim_to_check.validate_signature(address_to_check,
-                                                                         decoded_claim)
-                    if is_valid:
-                        self.db_signed_claims.delete(claim_id_to_check)
-                        self.db_signed_claims.put(claim_id_to_check, claim_id)
-                        print_log("validated lbry://{}#{}/{}".format(claim.name,
-                                                                     decoded_claim.certificate_id,
-                                                                     name))
-                    else:
-                        raise BadSignatureError()
-                except BadSignatureError:
-                    print_log("revoked lbry://{}#{}/{}".format(claim.name, claim_id, name))
-                    self.db_signed_claims.delete(claim_id_to_check)
-        elif decoded_claim.has_signature:
-            raw_certificate = self.db_certificate_claims.get(decoded_claim.certificate_id)
-            if not raw_certificate:
-                print_log("certificate error, revoking lbry://{}#{}".format(claim.name, claim_id))
-                self.db_signed_claims.delete(claim_id)
-            elif decoded_claim.has_signature:
-                certificate = smart_decode(raw_certificate)
-                channel_name = self.get_claim_name(decoded_claim.certificate_id)
-                try:
-                    is_valid = decoded_claim.validate_signature(claim_address, certificate)
-                except BadSignatureError:
-                    is_valid = False
-                if is_valid:
-                    print_log("validated lbry://{}#{}/{}".format(channel_name,
-                                                                 decoded_claim.certificate_id,
-                                                                 claim.name))
-                    self.db_signed_claims.put(claim_id, decoded_claim.certificate_id)
-                else:
-                    print_log("revoked lbry://{}#{}/{}".format(channel_name,
-                                                               decoded_claim.certificate_id,
-                                                               claim.name))
-                    self.db_signed_claims.delete(claim_id)
-        elif self.db_signed_claims.get(claim_id):
-            print_log("update to lbry://{}#{} is missing a signature, invalidating".format(claim.name, claim_id))
-            self.db_signed_claims.delete(claim_id)
-        elif self.db_certificate_claims.get(claim_id):
-            print_log("update to lbry://{}#{} no longer contains a certificate, removing the channel".format(claim.name, claim_id))
-            for channel_claim_id in self.get_claims_signed_by(claim_id):
-                name = self.get_claim_name(channel_claim_id)
-                print_log("invalidated lbry://{}#{}/{}".format(claim.name, claim_id, name))
-                self.db_signed_claims.delete(channel_claim_id)
-            self.db_certificate_claims.delete(claim_id)
-
-    def import_claim(self, claim, txid, nout, block_height, claim_address):
-        txid_nout = txid+int_to_hex(nout, 4)
-        is_update = type(claim) == deserialize.ClaimUpdate
-
-        if type(claim) not in [deserialize.NameClaim, deserialize.ClaimUpdate]:
-            raise Exception("No claim given to import")
-        if is_update:
-            claim_id = deserialize.claim_id_bytes_to_hex(claim.claim_id)
-            print_log("importing update to %s#%s" % (claim.name, claim_id))
-        else:
-            claim_id = self._get_claim_id(txid, nout)
-            print_log("importing claim %s#%s" % (claim.name, claim_id))
-
-        claims_in_db = self.db_claim_order.get(claim.name)
-        claims_for_name = {} if not claims_in_db else json.loads(claims_in_db)
-        if not claims_for_name:
-            claim_n = 1
-        else:
-            claim_n = max(i for i in claims_for_name.itervalues()) + 1
-
-        claims_for_name[claim_id] = claim_n
-        self.db_claim_order.delete(claim.name)
-        self.db_claim_order.put(claim.name, json.dumps(claims_for_name))
-
-        self.db_claimid.put(claim_id, txid_nout)
-        self.db_claim_names.put(claim_id, claim.name)
-        self.db_claim_values.put(claim_id, claim.value)
-        self.db_claim_height.put(claim_id, str(block_height))
-        self.db_claim_addrs.put(claim_id, claim_address)
-
-        self.update_channel_validations(claim, claim_id)
-
-    def remove_claim(self, claim_id, delete_claim_data=True):
-        name = self.get_claim_name(claim_id)
-        if delete_claim_data:
-            print_log("remove %s#%s" % (name, claim_id))
-            self.db_claimid.delete(claim_id)
-            self.db_claim_values.delete(claim_id)
-            self.db_claim_height.delete(claim_id)
-            self.db_claim_addrs.delete(claim_id)
-            self.db_claim_names.delete(claim_id)
-            self.batch_write()
-        else:
-            print_log("found non channel claim %s#%s" % (name, claim_id))
-
-        if self.db_certificate_claims.get(claim_id):
-            claims_signed_by_this_cert = self.get_claims_signed_by(claim_id)
-            for revoked_signed_claim in claims_signed_by_this_cert:
-                print_log("revoke %s#%s/%s" % (name, claim_id, self.get_claim_name(revoked_signed_claim)))
-                self.db_signed_claims.delete(revoked_signed_claim)
-            self.db_certificate_claims.delete(claim_id)
-        elif self.db_signed_claims.get(claim_id):
-            self.db_signed_claims.delete(claim_id)
-
-    def revert_claim(self, claim, txid, nout, undo_claim=None):
-        if type(claim) == deserialize.NameClaim:
-            claim_id = self._get_claim_id(txid, nout)
-            self.db_claimid.delete(claim_id)
-            self.db_claim_values.delete(claim_id)
-            self.db_claim_height.delete(claim_id)
-            print_log('Removing name claim {}'.format(claim_id))
-        elif type(claim) == deserialize.ClaimUpdate:
-            if not isinstance(undo_claim, dict):
-                print_log("Not given a value to revert claim to")
-
-            prev_txid_nout = undo_claim.pop('prev_txid_nout')
-            prev_claim_height = undo_claim.pop('prev_claim_height')
-            prev_claim_value = undo_claim.pop('prev_claim_value')
-
-            # delete the update and put the original claim back in
-            claim_id = deserialize.claim_id_bytes_to_hex(claim.claim_id)
-            self.db_claimid.delete(claim_id)
-            self.db_claim_values.delete(claim_id)
-            self.db_claim_height.delete(claim_id)
-
-            self.db_claimid.put(claim_id, prev_txid_nout)
-            self.db_claim_height.put(claim_id, prev_claim_height)
-            self.db_claim_values.put(claim_id, prev_claim_value)
-            print_log('Reverting update for claim {} to {}'.format(claim_id, prev_txid_nout))
-
-        assert undo_claim == {}
 
     def import_transaction(self, txid, tx, block_height, touched_addr):
         undo = {


### PR DESCRIPTION
Rewrite of channels update to handle block reorgs properly via the proper creation and storage of undo information when incrementing blocks. The undo information is retrieved and applied when decrementing blocks. Other major changes: 

- Claims related functions have been moved out of the storage.Storage class into claims_storage.ClaimsStorage class which inherits from storage.Storage 

- db_claimid renamed to db_claim_outpoint , and now stores the amount in addition to txid and nout

- reworked how signed claims are handled. No signature verifications performed in lbryum-server. Only stores and returns certificate ids that claims say they are attached to via metadata. 

This PR was tested using newly created lbry-in-a-box/lbryum_testing.py to test the reorgs, and lbry-in-a-box/integration_testing.py tests for normal claims operation without reorgs.
