### PR TITLE
Fix handling of updates for signed/unsigned claims

### DIFF
--- a/lbryumserver/blockchain_processor.py
+++ b/lbryumserver/blockchain_processor.py
@@ -519,6 +519,7 @@ class BlockchainProcessorBase(Processor):
 
     def get_claim_info(self, claim_id):
         result = {}
+        claim_id = str(claim_id)
         logger.warn("get_claim_info claim_id:{}".format(claim_id))
         claim_name = self.storage.get_claim_name(claim_id)
         claim_value = self.storage.get_claim_value(claim_id)
@@ -975,7 +976,7 @@ class BlockchainProcessor(BlockchainProcessorBase):
 
         result = {'proof': proof}
         if 'txhash' in proof and 'nOut' in proof:
-            txid, nout = proof['txhash'], proof['nOut']
+            txid, nout = str(proof['txhash']), int(proof['nOut'])
             transaction_info = self.lbrycrdd('getrawtransaction', (proof['txhash'], 1))
             transaction = transaction_info['hex']
             transaction_height = self.lbrycrdd_height - transaction_info['confirmations']

--- a/lbryumserver/claims_storage.py
+++ b/lbryumserver/claims_storage.py
@@ -140,6 +140,7 @@ class ClaimsStorage(Storage):
             # claim is invalid if its name does not match
             # what its updating
             if claim_name != claim.name:
+                logger.warn('found invalid update, name mismatch,{}/{}'.format(claim_name,claim.name))
                 return False
             # claim is invalid if it does not spend the claim it
             # is updating
@@ -149,7 +150,7 @@ class ClaimsStorage(Storage):
                 logger.warn("txid:{}, nout:{}, claim id:{}, claim id from outpoint:{}".format(txid, nout,claim_id,self.get_claim_id_from_outpoint(txid, nout)))
                 if claim_id == self.get_claim_id_from_outpoint(txid, nout):
                     return True
-            logger.warn("found invalid update {} for {}".format(claim_id, claim.name))
+            logger.warn("found invalid update, claim not found: {} for {}".format(claim_id, claim.name))
             return False
         else:
             return True

--- a/lbryumserver/claims_storage.py
+++ b/lbryumserver/claims_storage.py
@@ -155,6 +155,7 @@ class ClaimsStorage(Storage):
             return True
 
     def revert_claim_transaction(self, undo_infos):
+        log.info('reverting claim:{}'.format(undo_infos))
         """ revert claim transaction using undo information"""
         for undo_info in undo_infos:
             claim_id = undo_info['claim_id']
@@ -168,7 +169,7 @@ class ClaimsStorage(Storage):
                 self.db_claim_addrs.put(claim_id, undo_info['claim_addrs'])
                 self.db_claim_order.put(claim_name, undo_info['claim_order'])
                 self.db_outpoint_to_claim.delete(undo_info['outpoint_to_claim'])
-                self.db_outpoint_to_claim.put(undo_info['claim_outpoint'], claim_id)
+                self.db_outpoint_to_claim.put(undo_info['claim_outpoint'][0:72], claim_id)
 
                 # updated to signed claim
                 if 'cert_to_claims' in undo_info:
@@ -316,6 +317,7 @@ class ClaimsStorage(Storage):
         return undo_info
 
     def import_abandon(self, txid, nout):
+        logger.info("importing abandon txid:{}, nout:{} ".format(txid, nout))
         """ handle abandoned claims """
         claim_id = self.get_claim_id_from_outpoint(txid, nout)
         claim_name = self.get_claim_name(claim_id)

--- a/lbryumserver/claims_storage.py
+++ b/lbryumserver/claims_storage.py
@@ -379,7 +379,7 @@ class ClaimsStorage(Storage):
             decoded_claim = smart_decode(claim.value)
             parsed_uri = parse_lbry_uri(claim.name)
         except Exception as e:
-            logger.warn("decode error {} for lbry://{}#{}".format(e, claim.name, claim_id))
+            logger.warn("decode error for lbry://{}#{}".format(claim.name, claim_id))
             decoded_claim = None
             cert_id = None
         else:

--- a/lbryumserver/storage.py
+++ b/lbryumserver/storage.py
@@ -195,6 +195,9 @@ class Storage(object):
             self.db_undo_claim = DB(self.dbpath, 'undo_claim', 256 * 1024 * 1024)
             # key = claim id hex, value = txid hex sting + nout + amount
             self.db_claim_outpoint = DB(self.dbpath, 'claim_outpoint', config.getint('leveldb', 'claimid_cache'))
+            # key =  txid+ nout , value = claim id hex
+            self.db_outpoint_to_claim = DB(self.dbpath, 'outpoint_to_claim', 8*1024*1024)
+
             # key = claim id hex, value = claim name
             self.db_claim_names = DB(self.dbpath, 'claim_names', 64 * 1024 * 1024)
             # key = claim id hex, value = claim value

--- a/lbryumserver/storage.py
+++ b/lbryumserver/storage.py
@@ -566,6 +566,7 @@ class Storage(object):
 
     def batch_write(self):
         for db in [self.db_utxo, self.db_addr, self.db_hist, self.db_undo, self.db_claim_outpoint,
+                   self.db_outpoint_to_claim,
                    self.db_claim_values, self.db_claim_height, self.db_claim_names,
                    self.db_claim_order, self.db_cert_to_claims, self.db_claim_to_cert,
                    self.db_claim_addrs]:
@@ -573,6 +574,7 @@ class Storage(object):
 
     def close(self):
         for db in [self.db_utxo, self.db_addr, self.db_hist, self.db_undo, self.db_claim_outpoint,
+                   self.db_outpoint_to_claim,
                    self.db_claim_values, self.db_claim_height, self.db_claim_names,
                    self.db_claim_order, self.db_cert_to_claims, self.db_claim_to_cert,
                    self.db_claim_addrs]:


### PR DESCRIPTION
Needed to properly handle cases where updates could change a signed claim to unsigned , or change a unsigned claim to signed, and also handle reorgs of these cases. 

Split up import_signed_claim into import_signed_update and import_signed_claim.

Renamed import_signed_claim_abandon to import_signed_abandon. 

Added tests for signed updates in lbry-in-a-box lbryum testing. 