### PR TITLE
Fix incomplete address histories

### DIFF
--- a/lbryumserver/blockchain_processor.py
+++ b/lbryumserver/blockchain_processor.py
@@ -454,8 +454,8 @@ class BlockchainProcessorBase(Processor):
 
         # add undo info
         if not revert:
-            self.storage.write_undo_info(block_height, self.lbrycrdd_height, undo_info)
-            self.storage.write_undo_claim_info(block_height, self.lbrycrdd_height, claim_undo_info)
+            self.storage.write_undo_info(block_height, undo_info)
+            self.storage.write_undo_claim_info(block_height, claim_undo_info)
 
         # add the max
         self.storage.save_height(block_hash, block_height)

--- a/lbryumserver/claims_storage.py
+++ b/lbryumserver/claims_storage.py
@@ -101,15 +101,14 @@ class ClaimsStorage(Storage):
         return self.db_claim_names.get(claim_id)
 
     def get_undo_claim_info(self, height):
-        s = self.db_undo_claim.get("undo_info_%d"%(height%100))
+        s = self.db_undo_claim.get("undo_info_%d" % height)
         if s is None:
             print_log('no undo info for {}'.format(height))
             return None
         return pickle.loads(s)
 
-    def write_undo_claim_info(self, height, lbrycrdd_height, undo_info):
-        if height > lbrycrdd_height - 100 or self.test_reorgs:
-            self.db_undo_claim.put("undo_info_%d" % (height % 100), pickle.dumps(undo_info))
+    def write_undo_claim_info(self, height, undo_info):
+        self.db_undo_claim.put("undo_info_%d" % height, pickle.dumps(undo_info))
 
     def _get_claim_id(self, txid, nout):
         """ get claim id in hex from txid in hex and nout int """

--- a/lbryumserver/main.py
+++ b/lbryumserver/main.py
@@ -129,7 +129,6 @@ def create_config(filename=None):
 
     config.add_section('leveldb')
     config.set('leveldb', 'path', os.path.join(DEFAULT_DATA_DIR, 'lbryum_db'))
-    config.set('leveldb', 'pruning_limit', '100')
     config.set('leveldb', 'utxo_cache', str(64 * 1024 * 1024))
     config.set('leveldb', 'hist_cache', str(128 * 1024 * 1024))
     config.set('leveldb', 'addr_cache', str(16 * 1024 * 1024))

--- a/lbryumserver/main.py
+++ b/lbryumserver/main.py
@@ -130,7 +130,7 @@ def create_config(filename=None):
     config.add_section('leveldb')
     config.set('leveldb', 'path', os.path.join(DEFAULT_DATA_DIR, 'lbryum_db'))
     config.set('leveldb', 'utxo_cache', str(64 * 1024 * 1024))
-    config.set('leveldb', 'hist_cache', str(128 * 1024 * 1024))
+    config.set('leveldb', 'hist_cache', str(80 * 1024))
     config.set('leveldb', 'addr_cache', str(16 * 1024 * 1024))
     config.set('leveldb', 'claimid_cache', str(16 * 1024 * 1024 * 8))
 

--- a/lbryumserver/storage.py
+++ b/lbryumserver/storage.py
@@ -7,6 +7,7 @@ import ast
 import os
 import threading
 import json
+import re
 import pickle
 
 from ecdsa.keys import BadSignatureError
@@ -304,15 +305,14 @@ class Storage(object):
         for item in o:
             out.append((item['height'], item['tx_hash']))
         h = self.db_hist.get(addr)
-        while h:
-            item = h[0:80]
-            h = h[80:]
-            txi = item[0:32].encode('hex')
-            hi = hex_to_int(item[36:40])
-            txo = item[40:72].encode('hex')
-            ho = hex_to_int(item[76:80])
-            out.append((hi, txi))
-            out.append((ho, txo))
+        if h:
+            for item in re.findall('.{80}', h, flags=re.DOTALL):
+                txi = item[0:32].encode('hex')
+                hi = hex_to_int(item[36:40])
+                txo = item[40:72].encode('hex')
+                ho = hex_to_int(item[76:80])
+                out.append((hi, txi))
+                out.append((ho, txo))
         # uniqueness
         out = set(out)
         # sort by height then tx_hash

--- a/lbryumserver/storage.py
+++ b/lbryumserver/storage.py
@@ -334,15 +334,14 @@ class Storage(object):
 
 
     def get_undo_info(self, height):
-        s = self.db_undo.get("undo_info_%d" % (height % 100))
+        s = self.db_undo.get("undo_info_%d" % height)
         if s is None:
             print_log("no undo info for ", height)
             return None
         return pickle.loads(s)
 
-    def write_undo_info(self, height, lbrycrdd_height, undo_info):
-        if height > lbrycrdd_height - 100 or self.test_reorgs:
-            self.db_undo.put("undo_info_%d" % (height % 100), pickle.dumps(undo_info))
+    def write_undo_info(self, height, undo_info):
+        self.db_undo.put("undo_info_%d" % height, pickle.dumps(undo_info))
 
     @staticmethod
     def common_prefix(word1, word2):


### PR DESCRIPTION
Fixes https://github.com/lbryio/lbryum-server/issues/36

The above issue was fixed in 51af6d1 - the beginnings of the histories were being cropped off as to leave at most 100 items.

After the above, it was necessary to reduce the hist_cache size in 4d0728a (it was also supposed to be a multiple of 80, which it is now), otherwise the lbryum-server process runs out of memory.

3b595b6 allows reverting the blockchain beyond the current limit of 100 blocks, which I found useful for testing (but it is not a part of the bug fix).