### PR TITLE
added Deferreds for TcpServer starting/stopping to be used in unit tests

### DIFF
--- a/lbryumserver/main.py
+++ b/lbryumserver/main.py
@@ -330,6 +330,8 @@ def start_server(config):
     for server in transports:
         server.start()
 
+    return transports
+
 
 def stop_server():
     shared.stop()


### PR DESCRIPTION
Could be useful for other reasons too... in case you want to build a monitoring tool ontop of lbryum-server, this will let you know when it started and stopped. see lbrytest for usage example.